### PR TITLE
Autocomplete instructions with most updated node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,23 @@ There are 3 ways to set `constants.ts`:
 
 1. With just validator public keys, as in `constants.expamle1.ts`. This will try to create instructions, relaying
    on the [monitor's API](https://monitor.incognito.org).
+
 2. Setting your own instructions, as in `constants.example2.ts`. This is an alternative if the first option fails
-   or if you want to take control over the instructions.
+   or if you want to take control over the instructions. `fromNodeIndex` is optional. You could write it like this:
+
+   ```js
+   instructions: [
+      {
+         shardName: "beacon",
+         toNodesIndex: [0, 1, 2, 3, 4, 5],
+      },
+   ],
+   ```
+
+   The script will set `fromNodeIndex` to the node who has more files in the shard's directory, effectively
+   choosing the most updated to be the seeder. The chosen node will always be one which won't be skipped. Nodes can
+   be skipped if they are about or in `COMMITEE` or for other reasons.
+
 3. Same as 2, but with a fullnode as source or any other data source, as in `constants.example3.ts`.
 
 # Dependencies

--- a/index.ts
+++ b/index.ts
@@ -8,16 +8,15 @@ import { docker, rm, cp, chown, getExtraFiles, dockerPs } from "./utils/commands
 const { validatorPublicKeys = {}, homePath } = constants;
 
 try {
-  console.log("Getting instructions.");
-  const instructions = await getInstructions();
-  console.log("Instructions:");
-  console.log(instructions);
-
-  console.group("\nGetting node info.");
+  console.group("Getting node info.");
   const dockerStatus = flags.keepStatus && !flags.onlyOffline ? await dockerPs() : {};
   const nodesStatus = await getNodesStatus();
   console.table(nodesStatus);
   console.groupEnd();
+
+  console.log("\nGetting instructions.");
+  const instructions = await getInstructions(nodesStatus);
+  console.log(instructions);
 
   console.group("\nStopping containers.");
 

--- a/types/constants.type.ts
+++ b/types/constants.type.ts
@@ -1,6 +1,6 @@
 import { ShardsNames } from "./shards.type.ts";
 
-interface InstructionIncomplete {
+export interface InstructionIncomplete {
   shardName: ShardsNames;
   toNodesIndex: (keyof Constants["validatorPublicKeys"])[];
 }
@@ -19,7 +19,7 @@ export type ValidatorPublicKeys = Record<number, string>;
 export default interface Constants {
   homePath: string;
   extraDockers?: string[];
-  instructions?: Instruction[];
+  instructions?: (Instruction | InstructionIncomplete)[];
   maxEpochsToNextEvent?: number;
   validatorPublicKeys: ValidatorPublicKeys;
 }

--- a/utils/getInstructions.ts
+++ b/utils/getInstructions.ts
@@ -1,12 +1,50 @@
 import constants from "../constants.ts";
-import { Instruction } from "../types/constants.type.ts";
+import { Instruction, InstructionIncomplete } from "../types/constants.type.ts";
 import { nodesDB } from "../db/collections/collections.ts";
 import Shards, { ShardsNames } from "../types/shards.type.ts";
 import checkIfAllShardsHaveSeed from "./checkIfAllShardsHaveSeed.ts";
 import checkIfConstantsHaveChanged from "./checkIfConstantsHaveChanged.ts";
+import { NodesStatus } from "./getNodesStatus.ts";
+import getNumberOfFiles from "./getNumberOfFiles.ts";
 
-export default async function getInstructions() {
-  if ("instructions" in constants && constants.instructions instanceof Array) return constants.instructions;
+export default async function getInstructions(nodesStatus: NodesStatus) {
+  // If the instructions are already defined in the constants file, then just return them.
+  if ("instructions" in constants && constants.instructions instanceof Array) {
+    // If it has a fromNodeIndex or fromPath, then it's already complete.
+    if ("fromNodeIndex" in constants.instructions[0] || "fromPath" in constants.instructions[0])
+      return constants.instructions as Instruction[];
+
+    // This is for the case where you want to get the most updated node in toNodesIndex and set it
+    // as the fromNodeIndex.
+    const instructions: Instruction[] = [];
+    for (const instruction of constants.instructions as InstructionIncomplete[]) {
+      // The nodes which are NOT going to be skipped
+      const finalNodes = instruction.toNodesIndex.filter((nodeIndex) => nodesStatus[nodeIndex].skip === false);
+
+      // At least two nodes are required.
+      if (finalNodes.length < 2) continue;
+
+      const totalFilesForNodes = finalNodes.reduce((obj, nodeIndex) => {
+        obj[nodeIndex] = getNumberOfFiles(
+          `${constants.homePath}/node_data_${nodeIndex}/mainnet/block/${instruction.shardName}`
+        );
+        return obj;
+      }, {} as Record<string, number>);
+
+      let mostUpdatedNode = -1;
+      for (const nodeIndex of finalNodes)
+        if (mostUpdatedNode === -1 || totalFilesForNodes[nodeIndex] > totalFilesForNodes[mostUpdatedNode])
+          mostUpdatedNode = nodeIndex;
+
+      instructions.push({
+        shardName: instruction.shardName,
+        fromNodeIndex: mostUpdatedNode,
+        toNodesIndex: finalNodes.filter((nodeIndex) => nodeIndex !== mostUpdatedNode),
+      });
+    }
+
+    return instructions;
+  }
 
   const instructions: Instruction[] = [];
 

--- a/utils/getInstructions.ts
+++ b/utils/getInstructions.ts
@@ -29,10 +29,9 @@ export default async function getInstructions(nodesStatus: NodesStatus) {
         return obj;
       }, {} as Record<string, number>);
 
-      let mostUpdatedNode = -1;
-      for (const nodeIndex of activeNodes)
-        if (mostUpdatedNode === -1 || totalFilesPerNode[nodeIndex] > totalFilesPerNode[mostUpdatedNode])
-          mostUpdatedNode = nodeIndex;
+      let mostUpdatedNode = activeNodes[0] ?? instruction.toNodesIndex[0];
+      for (const nodeIndex of activeNodes.slice(1))
+        if (totalFilesPerNode[nodeIndex] > totalFilesPerNode[mostUpdatedNode]) mostUpdatedNode = nodeIndex;
 
       instructions.push({
         shardName: instruction.shardName,

--- a/utils/getNodesStatus.ts
+++ b/utils/getNodesStatus.ts
@@ -63,7 +63,7 @@ export default async function getNodesStatus() {
       const nodeIndex = Object.entries(validatorPublicKeys).find(([, mpk]) => mpk === MiningPubkey)?.[0];
       if (!nodeIndex) continue;
       // get first number from string using regex and parse it to number
-      const epochsToNextEvent = Number(NextEventMsg.match(/^\d+/)?.[0] ?? 0);
+      const epochsToNextEvent = Number(NextEventMsg.match(/\d+/)?.[0] ?? 0);
       nodesStatus[nodeIndex] = {
         role: Role,
         epochsToNextEvent,

--- a/utils/getNumberOfFiles.ts
+++ b/utils/getNumberOfFiles.ts
@@ -1,0 +1,6 @@
+export default function getNumberOfFiles(path: string) {
+  const dir = Deno.readDirSync(path);
+  let i = 0;
+  for (; dir[Symbol.iterator]().next().done !== true; i++);
+  return i;
+}


### PR DESCRIPTION
If you set your instructions in `constants.ts` without any `fromPath` or `fromNodeIndex`, like this:

```js
instructions: [
  {
    shardName: "beacon",
    toNodesIndex: [0, 1, 2, 3, 4, 5],
  },
],
```

the script will set fromNodeIndex to the node who has more files in the respective shard, effectively choosing the most updated. The node chosen will always be a node which won't be skipped.